### PR TITLE
Bump base amazoncorreto images (Support #732)

### DIFF
--- a/dockerfile/flex-ce/Dockerfile
+++ b/dockerfile/flex-ce/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17.0.15
+FROM amazoncorretto:17.0.16
 
 ARG VERSION
 ARG RELEASE

--- a/dockerfile/flex/Dockerfile
+++ b/dockerfile/flex/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17.0.15
+FROM amazoncorretto:17.0.16
 
 ARG VERSION
 ARG RELEASE


### PR DESCRIPTION
[#732 - CVE-2025-49794 in libxml2](https://factorhouse.zendesk.com/agent/tickets/732)

> Does the upcoming Kpow 94.5 contain a fix for [CVE-2025-49794](https://nvd.nist.gov/vuln/detail/CVE-2025-49794)? If so, when do you expect the GA release? We realize that Kpow probably isn't exposed to this CVE, but this still gets flagged in our environment.

- `17.0.15` [lists 11 vulns](https://hub.docker.com/layers/library/amazoncorretto/17.0.15/images/sha256-212007013e11f833303bca461ac80301da6ce94d4b0564f0b2733556c369a11d), including CVE-2025-49794
- `17.0.16` [lists 6 vulns](https://hub.docker.com/layers/library/amazoncorretto/17.0.16/images/sha256-54e19c7aef2995ee1452ae1c11361f886b1fffbad4104ea9c01ca113fcd4ae05) _also including_ CVE-2025-49794